### PR TITLE
Add cross compilation for Scala 2.11 as well as 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
-scalaVersion in ThisBuild := "2.12.3"
+scalaVersion in ThisBuild := "2.12.4"
+crossScalaVersions in ThisBuild := Seq("2.12.4", "2.11.12")
 organization in ThisBuild := "com.scalawilliam"
-version in ThisBuild := "0.4"
+version in ThisBuild := "0.5"
 
 lazy val root = (project in file("."))
   .aggregate(core, examples)
@@ -8,9 +9,8 @@ lazy val root = (project in file("."))
 
 lazy val core = project.settings(
   libraryDependencies ++= Seq(
-    "xmlunit" % "xmlunit" % "1.6",
+    "xmlunit" % "xmlunit" % "1.6" % "test",
     "org.codehaus.woodstox" % "woodstox-core-asl" % "4.4.1",
-    "org.compass-project" % "compass" % "2.2.0",
     "org.scalatest" %% "scalatest" % "3.0.4" % "test",
     "org.scala-lang.modules" %% "scala-xml" % "1.0.6"
   ),


### PR DESCRIPTION
I needed a streaming XML parser in a Scala project, and xs4s does exactly what I need. However, not all of the projects where I might use it have migrated to Scala 2.12 yet hence this PR adding cross compilation for Scala 2.11 and 2.12.

It'd be great if you'd be willing to include this change, as the library works really well so I'd really like to use it!

I also removed the dependency on 'compass' as that didn't seem to be used, and limited the 'xmlunit' dependency to only the "test" scope. Hope this makes sense.