### PR TITLE
fs2 fromBlockingIterator chunkSize to greatly speed up parsing

### DIFF
--- a/fs2/src/main/scala/xs4s/fs2compat/Fs2Syntax.scala
+++ b/fs2/src/main/scala/xs4s/fs2compat/Fs2Syntax.scala
@@ -27,14 +27,15 @@ trait Fs2Syntax {
     /** Create an XMLEvent Stream from an XMLEventReader */
     def xmlEventStream[F[_]: ContextShift: Sync](
         blocker: Blocker,
-        xmlEventReader: Resource[F, XMLEventReader]): Stream[F, XMLEvent] =
+        xmlEventReader: Resource[F, XMLEventReader],
+        chunkSize: Int = 1): Stream[F, XMLEvent] =
       Stream
         .resource(xmlEventReader)
         .flatMap(
           reader =>
             Stream
               .fromBlockingIterator[F]
-              .apply[XMLEvent](blocker, reader.toIterator))
+              .apply[XMLEvent](blocker, reader.toIterator, chunkSize))
   }
 
   implicit class RichXmlElementExtractor[O](

--- a/fs2/src/main/scala/xs4s/fs2compat/package.scala
+++ b/fs2/src/main/scala/xs4s/fs2compat/package.scala
@@ -18,7 +18,8 @@ package object fs2compat {
     * */
   def byteStreamToXmlEventStream[F[_]: ConcurrentEffect: ContextShift](
       blocker: Blocker,
-      xmlInputFactory: XMLInputFactory = defaultXmlInputFactory)(
+      xmlInputFactory: XMLInputFactory = defaultXmlInputFactory,
+      chunkSize: Int = 1)(
       implicit F: Sync[F]): Pipe[F, Byte, XMLEvent] =
     byteStream =>
       Stream
@@ -29,5 +30,6 @@ package object fs2compat {
               blocker,
               Resource.make(
                 F.delay(xmlInputFactory.createXMLEventReader(inputStream)))(
-                xmlEventReader => F.delay(xmlEventReader.close()))))
+                xmlEventReader => F.delay(xmlEventReader.close())),
+              chunkSize))
 }


### PR DESCRIPTION
This PR makes the chunkSize used in Stream.fromBlockingIterator configurable to speed up the parsing of xml events by orders of magnitude.
Right now each xml event is streamed as a chunk which makes the parsing quite slow but by using the chunkSize parameter fs2 can pull multiple elements from the iterator at once.
This PR might introduce binary incompatibility.