### PR TITLE
Update woodstox to latest 6.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val root = (project in file("."))
 lazy val core = project.settings(
   libraryDependencies ++= Seq(
     "xmlunit"                % "xmlunit"           % "1.6" % "test",
-    "org.codehaus.woodstox"  % "woodstox-core-asl" % "4.4.1",
+    "com.fasterxml.woodstox" % "woodstox-core"     % "6.5.1",
     "org.scalatest"          %% "scalatest"        % "3.2.9" % "test",
     "org.scala-lang.modules" %% "scala-xml"        % "2.0.1"
   ),


### PR DESCRIPTION
All tests pass with this change and everything should be compatible. The [woodstox README](https://github.com/FasterXML/woodstox#maven) says:

> Note that Maven id has changed since Woodstox 4.x but API is still compatible (despite nominal major version upgrade -- major version upgrades in this case were only due to package coordinate changes)